### PR TITLE
style.css/去除引入line.png图片上面的a.main引入

### DIFF
--- a/source/css/style.css
+++ b/source/css/style.css
@@ -149,7 +149,7 @@ a, .as-link {
   -ms-transition: color 0.3s;
   -o-transition: color 0.3s;
   transition: color 0.3s; }
-  a.main, a:hover, .as-link.main, .as-link:hover {
+  a:hover, .as-link.main, .as-link:hover {
     color: #1d5884;
     background-image: url(../images/line.png);
     background-repeat: repeat-x;


### PR DESCRIPTION
这种改动直接方便了后人，不会因为导航栏的底色一直在而恼火，而换用其他的主题。